### PR TITLE
Return the name/key from the enum value or undefined

### DIFF
--- a/src/enumValues.d.ts
+++ b/src/enumValues.d.ts
@@ -4,5 +4,6 @@ export declare class EnumValues {
         value: number;
     }[];
     static getNames(e: any): string[];
+    static getNameFromValue(e: any, l: (number | string)): string;
     static getValues(e: any): (string | number)[];
 }

--- a/src/enumValues.js
+++ b/src/enumValues.js
@@ -9,6 +9,10 @@ var EnumValues = (function () {
     EnumValues.getNames = function (e) {
         return Object.keys(e).filter(function (key) { return isNaN(+key); });
     };
+    EnumValues.getNameFromValue = function (e, l) {
+        var all = this.getNamesAndValues(e).filter(function (val) { return val.value == l; });
+        return all.length == 1 ? all[0].name : undefined;
+    };
     EnumValues.getValues = function (e) {
         return this.getNames(e).map(function (name) { return e[name]; });
     };

--- a/src/enumValues.test.js
+++ b/src/enumValues.test.js
@@ -16,6 +16,13 @@ describe('EnumValues', function () {
         it('getValues should return correct values', function () {
             chai_1.expect(enumValues_1.EnumValues.getValues(NumericValuesTestEnum)).to.deep.equal([0, 1, 2]);
         });
+        it('getNameFromValue should return the key for that value', function () {
+            var expectedResult = "B";
+            chai_1.expect(enumValues_1.EnumValues.getNameFromValue(NumericValuesTestEnum, 1)).equal(expectedResult);
+        });
+        it('getNameFromValue should return undefined', function () {
+            chai_1.expect(enumValues_1.EnumValues.getNameFromValue(NumericValuesTestEnum, 11)).equal(undefined);
+        });
         it('getNamesAndValues should return correct values', function () {
             var expectedResult = [
                 { name: 'A', value: 0 },
@@ -34,6 +41,10 @@ describe('EnumValues', function () {
         })(StringValuesTestEnum || (StringValuesTestEnum = {}));
         it('getNames should return correct values', function () {
             chai_1.expect(enumValues_1.EnumValues.getNames(StringValuesTestEnum)).to.deep.equal(['A', 'B', 'C']);
+        });
+        it('getNameFromValue should return the key for that value', function () {
+            var expectedResult = "B";
+            chai_1.expect(enumValues_1.EnumValues.getNameFromValue(StringValuesTestEnum, 'BValue')).equal(expectedResult);
         });
         it('getValues should return correct values', function () {
             chai_1.expect(enumValues_1.EnumValues.getValues(StringValuesTestEnum)).to.deep.equal(['AValue', 'BValue', 'CValue']);

--- a/src/enumValues.test.ts
+++ b/src/enumValues.test.ts
@@ -1,3 +1,4 @@
+
 import { EnumValues } from "./enumValues";
 import { expect } from 'chai';
 
@@ -17,6 +18,16 @@ describe('EnumValues', () => {
 
     it('getValues should return correct values', () => {
       expect(EnumValues.getValues(NumericValuesTestEnum)).to.deep.equal([0, 1, 2]);
+    });
+
+    it('getNameFromValue should return the key for that value', () => {
+      var expectedResult = "B";
+      
+      expect(EnumValues.getNameFromValue(NumericValuesTestEnum, 1)).equal(expectedResult);
+    });
+
+    it('getNameFromValue should return undefined', () => {
+      expect(EnumValues.getNameFromValue(NumericValuesTestEnum, 11)).equal(undefined);
     });
 
     it('getNamesAndValues should return correct values', () => {
@@ -39,6 +50,12 @@ describe('EnumValues', () => {
 
     it('getNames should return correct values', () => {
       expect(EnumValues.getNames(StringValuesTestEnum)).to.deep.equal(['A', 'B', 'C']);
+    });
+
+    it('getNameFromValue should return the key for that value', () => {
+      var expectedResult = "B";
+      
+      expect(EnumValues.getNameFromValue(StringValuesTestEnum, 'BValue')).equal(expectedResult);
     });
 
     it('getValues should return correct values', () => {

--- a/src/enumValues.ts
+++ b/src/enumValues.ts
@@ -7,6 +7,11 @@ export class EnumValues {
     return Object.keys(e).filter(key => isNaN(+key))
   }
 
+  static getNameFromValue(e:any, l:(number|string)) {
+    var all= this.getNamesAndValues(e).filter(val=> { return val.value == l});
+    return all.length==1 ? all[0].name : undefined;
+  }
+
   static getValues(e: any) {
     return this.getNames(e).map(name => e[name]) as (number | string)[];
   }


### PR DESCRIPTION
Addition of the getNameFromValue method to return the key from the value.  There could be cases you may have the enum value (ie, 1) and want the key name (ie, active) especially when coming from a webservice that is returning the value and you want to show the key name.

Addition of a few tests.