### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "enum"
   ],
   "author": "Slava Shpitalny <slavik57@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/slavik57/enum-values/issues"
   },


### PR DESCRIPTION
Should be `MIT` accorting to LICENSE file, instead of node/npm's default `ISC`