### PR TITLE
Export default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 Library for getting the names and values of typescript enum
 
 ## Installation
-```
+
+```shell
 npm install enum-values --save
 ```
 
-
 ### Example in TypeScript
-```javascript
-  import { EnumValues } from 'enum-values';
+
+```typescript
+  import EnumValues from 'enum-values';
 
   // Suppose we have an numeric and a string valued enum
   enum NumericEnum {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export { EnumValues } from './src/enumValues';
+export * from './src/enumValues';

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 "use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
 Object.defineProperty(exports, "__esModule", { value: true });
-var enumValues_1 = require("./src/enumValues");
-exports.EnumValues = enumValues_1.EnumValues;
+__export(require("./src/enumValues"));

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export { EnumValues } from './src/enumValues';
+export * from './src/enumValues';

--- a/src/enumValues.d.ts
+++ b/src/enumValues.d.ts
@@ -8,3 +8,4 @@ export declare class EnumValues {
     static getNameFromValue<T extends EnumValueType>(e: any, value: T): string | null;
     static getValues<T extends EnumValueType>(e: any): T[];
 }
+export default EnumValues;

--- a/src/enumValues.js
+++ b/src/enumValues.js
@@ -19,3 +19,4 @@ var EnumValues = (function () {
     return EnumValues;
 }());
 exports.EnumValues = EnumValues;
+exports.default = EnumValues;

--- a/src/enumValues.ts
+++ b/src/enumValues.ts
@@ -18,3 +18,6 @@ export class EnumValues {
     return this.getNames(e).map(name => e[name]) as T[];
   }
 }
+
+// Also re-export as ES-2015 default export
+export default EnumValues;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "removeComments": true,
         "noLib": false,
         "preserveConstEnums": true,
-        "suppressImplicitAnyIndexErrors": true
+        "suppressImplicitAnyIndexErrors": true,
+        "esModuleInterop": true
     }
 }


### PR DESCRIPTION
Added ES-2015 support for default export and import default syntax usage below:

```typescript
import EnumValues from 'enum-values';
// before you had to do
import { EnumValues } from 'enum-values';
```

Also the emitted javascript code uses the `__esModule` indicator for CommonJS as indicated here (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html)

PS: why aren't generated `.js and .d.ts` files not excluded in `.gitignore`? I think they create a lot of noise in Pull Requests and merge conflicts